### PR TITLE
Methods for individual enums

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,32 +11,64 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.2, 8.3 ]
-        laravel: [ 10.*, 11.* ]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
+        laravel: [ 10.*, 11.*, 12.* ]
         include:
           - php: 8.1
             laravel: 10.*
             pest: 2.*
             testbench: 8.*
+            larastan: 2.*
           - php: 8.2
             laravel: 10.*
             pest: 2.*
             testbench: 8.*
+            larastan: 2.*
           - php: 8.3
             laravel: 10.*
             pest: 2.*
             testbench: 8.*
+            larastan: 2.*
+          - php: 8.4
+            laravel: 10.*
+            pest: 2.*
+            testbench: 8.*
+            larastan: 2.*
           - php: 8.2
             laravel: 11.*
             pest: 3.*
             testbench: 9.*
+            larastan: 2.*
           - php: 8.3
             laravel: 11.*
             pest: 3.*
             testbench: 9.*
+            larastan: 2.*
+          - php: 8.4
+            laravel: 11.*
+            pest: 3.*
+            testbench: 9.*
+            larastan: 2.*
+          - php: 8.2
+            laravel: 12.*
+            pest: 3.*
+            testbench: 10.*
+            larastan: 3.*
+          - php: 8.3
+            laravel: 12.*
+            pest: 3.*
+            testbench: 10.*
+            larastan: 3.*
+          - php: 8.4
+            laravel: 12.*
+            pest: 3.*
+            testbench: 10.*
+            larastan: 3.*
         exclude:
           - php: 8.1
             laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
 
     name: Paragon Tests - PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -45,7 +77,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -61,9 +93,10 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-          composer require "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
-          composer require "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-laravel:${{ matrix.pest }}" "pestphp/pest-plugin-type-coverage:${{ matrix.pest }}" --no-interaction --no-update --dev
-          composer update --prefer-dist --no-interaction --no-suggest --dev
+          composer require "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-laravel:${{ matrix.pest }}" "pestphp/pest-plugin-type-coverage:${{ matrix.pest }}" --no-interaction --no-update
+          composer require "larastan/larastan:${{ matrix.larastan }}" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
           composer dump
 
       - name: Execute tests
@@ -79,7 +112,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-composer-${{ hashFiles('composer.json') }}
@@ -92,7 +125,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer install --no-interaction --no-suggest --dev
+          composer install --no-interaction
           composer dump
 
       - name: Execute Pint
@@ -108,7 +141,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-composer-${{ hashFiles('composer.json') }}
@@ -121,7 +154,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer install --no-interaction --no-suggest --dev
+          composer install --no-interaction
           composer dump
 
       - name: Execute Larastan

--- a/README.md
+++ b/README.md
@@ -98,7 +98,15 @@ While this package ignores static methods on the PHP Enums, we allow you to crea
 php artisan paragon:enum:add-method
 ```
 
-This will create a new file at `resources/js/vendors/paragon/enums` containing a method. You are free to do whatever you need inside this file. You have direct access to `this.items` which allows you to interact with the enum cases in whatever way you need. Just keep in mind that because the items are "frozen", you can't mutate them directly. An example would be to have a method that automatically generates a select list from your Enum.
+You will be prompted to search for the enum this method should belong to. It will be placed inside a directory that matches the namespace of the enum. For example, an enum at `App\Enums\Status` would place an enum method file at `resources/js/vendors/paragon/enums/App/Enums/Status`. You are free to do whatever you need inside this file. You have direct access to `this.items` which allows you to interact with the enum cases in whatever way you need. Just keep in mind that because the items are "frozen", you can't mutate them directly. An example would be to have a method that automatically generates a select list from your Enum.
+
+If you need to create a method that is available to every enum, just create an enum method with the `--global` or `-g` flag.
+
+```bash
+php artisan paragon:enum-method --global
+```
+
+This will create a new file at `resources/js/vendors/paragon/enums` containing a method.
 
 ### Ignoring Enums Or Public Methods
 

--- a/src/Commands/GenerateEnumsCommand.php
+++ b/src/Commands/GenerateEnumsCommand.php
@@ -28,17 +28,26 @@ class GenerateEnumsCommand extends Command
     {
         $builder = $this->builder();
 
+        $this->generateEnums($builder);
+        $this->generateAbstractEnum($builder);
+
+        return self::SUCCESS;
+    }
+
+    protected function generateEnums(EnumBuilder $builder): void
+    {
         $generatedEnums = $this->enums()
             ->map(fn (ReflectionEnum $enum) => app(EnumGenerator::class, ['enum' => $enum, 'builder' => $builder])())
             ->filter();
 
         $this->components->info("{$generatedEnums->count()} enums have been (re)generated.");
+    }
 
+    protected function generateAbstractEnum(EnumBuilder $builder): void
+    {
         app(AbstractEnumGenerator::class, ['builder' => $builder])();
 
         $this->components->info('Abstract enum class has been (re)generated.');
-
-        return self::SUCCESS;
     }
 
     /**

--- a/src/Commands/MakeEnumMethodCommand.php
+++ b/src/Commands/MakeEnumMethodCommand.php
@@ -32,8 +32,8 @@ class MakeEnumMethodCommand extends GeneratorCommand
     /**
      * Execute the console command.
      *
-     * @throws Exception
      * @throws FileNotFoundException
+     * @throws Throwable
      */
     public function handle(): ?bool
     {

--- a/src/Commands/MakeEnumMethodCommand.php
+++ b/src/Commands/MakeEnumMethodCommand.php
@@ -5,14 +5,25 @@ namespace Kirschbaum\Paragon\Commands;
 use Exception;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Kirschbaum\Paragon\Concerns\Builders\EnumBuilder;
 use Kirschbaum\Paragon\Concerns\Builders\EnumJsBuilder;
 use Kirschbaum\Paragon\Concerns\Builders\EnumTsBuilder;
+use Kirschbaum\Paragon\Concerns\DiscoverEnums;
 use Kirschbaum\Paragon\Generators\AbstractEnumGenerator;
+use Kirschbaum\Paragon\Generators\EnumGenerator;
+use ReflectionEnum;
+use ReflectionException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+use UnitEnum;
 
+use function Laravel\Prompts\search;
 use function Laravel\Prompts\text;
 
 #[AsCommand(name: 'paragon:enum:add-method', description: 'Create a new global typescript method to be applied to every generated enum')]
@@ -28,9 +39,9 @@ class MakeEnumMethodCommand extends GeneratorCommand
     {
         parent::handle();
 
-        app(AbstractEnumGenerator::class, ['builder' => $this->builder()])();
+        $this->runGenerator();
 
-        $this->components->info("Abstract enum class has been rebuilt to include new [{$this->name()}] method.");
+        $this->writeInfo();
 
         return true;
     }
@@ -71,6 +82,38 @@ class MakeEnumMethodCommand extends GeneratorCommand
     }
 
     /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output): void
+    {
+        if (
+            is_string($this->option('enum'))
+            || $this->option('global')
+        ) {
+            return;
+        }
+
+        /**
+         * @var string $enumPath
+         */
+        $enumPath = config('paragon.enums.paths.php');
+
+        $enums = DiscoverEnums::within(app_path($enumPath))
+            ->mapWithKeys(fn (ReflectionEnum $reflector) => [$reflector->getName() => $reflector->getName()]);
+
+        $enum = search(
+            label: 'Which enum should this method be created for?',
+            options: fn (string $value) => strlen($value) > 0
+                ? $enums->filter(fn (string $enum): bool => Str::contains($enum, $value, ignoreCase: true))->all()
+                : []
+        );
+
+        $input->setOption('enum', $enum);
+    }
+
+    /**
      * Build the file with the given name.
      *
      * @param  string  $name
@@ -88,15 +131,30 @@ class MakeEnumMethodCommand extends GeneratorCommand
     /**
      * Get the destination class path.
      *
-     * @throws Exception
+     * @throws Throwable
      */
     protected function getPath($name): string
     {
-        /** @var string */
-        $methods = config('paragon.enums.paths.methods');
+        /**
+         * @var string $path
+         */
+        $path = config('paragon.enums.paths.methods');
         $extension = $this->option('javascript') ? 'js' : 'ts';
 
-        return resource_path($methods) . "/{$this->name()}.{$extension}";
+        if (! $this->option('global')) {
+            $enum = str($this->enumOption())->replace('/', '\\');
+
+            throw_unless(
+                enum_exists($enum->toString()),
+                ReflectionException::class,
+                "Class \"{$enum}\" does not exist"
+            );
+
+            $path = $enum->replace('\\', '/')
+                ->prepend(Str::finish($path, '/'));
+        }
+
+        return resource_path($path) . "/{$this->name()}.{$extension}";
     }
 
     /**
@@ -120,7 +178,48 @@ class MakeEnumMethodCommand extends GeneratorCommand
         return $this->option('javascript')
             ? app(EnumJsBuilder::class)
             : app(EnumTsBuilder::class);
+    }
 
+    /**
+     * @throws ReflectionException
+     * @throws Throwable
+     */
+    protected function runGenerator(): void
+    {
+        $this->option('global')
+            ? app(AbstractEnumGenerator::class, ['builder' => $this->builder()])()
+            : app(EnumGenerator::class, [
+                'enum' => new ReflectionEnum($this->enumOption()),
+                'builder' => $this->builder(),
+                'forceRegenerate' => true,
+            ])();
+    }
+
+    protected function writeInfo(): void
+    {
+        $name = $this->option('global')
+            ? 'Abstract'
+            : Str::afterLast($this->enumOption(), '\\');
+
+        $this->components->info("[{$name}] enum class has been rebuilt to include new [{$this->name()}()] method.");
+    }
+
+    /**
+     * @return class-string<UnitEnum>
+     *
+     * @throws Throwable
+     */
+    protected function enumOption(): string
+    {
+        $enum = $this->option('enum');
+
+        throw_unless(
+            is_string($enum) && is_a($enum, UnitEnum::class, true),
+            InvalidArgumentException::class,
+            'The enum option must be a valid class-string of a UnitEnum'
+        );
+
+        return $enum;
     }
 
     /**
@@ -131,6 +230,18 @@ class MakeEnumMethodCommand extends GeneratorCommand
     protected function getOptions(): array
     {
         return [
+            new InputOption(
+                name: 'enum',
+                shortcut: 'e',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Fully qualified namespace of enum to use',
+            ),
+            new InputOption(
+                name: 'global',
+                shortcut: 'g',
+                mode: InputOption::VALUE_NONE,
+                description: 'Create global enum method',
+            ),
             new InputOption(
                 name: 'javascript',
                 shortcut: 'j',

--- a/src/Concerns/DiscoverEnums.php
+++ b/src/Concerns/DiscoverEnums.php
@@ -5,8 +5,8 @@ namespace Kirschbaum\Paragon\Concerns;
 use Illuminate\Support\Collection;
 use ReflectionEnum;
 use ReflectionException;
-use SplFileInfo;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 use UnitEnum;
 
 class DiscoverEnums

--- a/src/Generators/AbstractEnumGenerator.php
+++ b/src/Generators/AbstractEnumGenerator.php
@@ -6,10 +6,10 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Kirschbaum\Paragon\Concerns\Builders\EnumBuilder;
-use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem as FileUtility;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class AbstractEnumGenerator
 {
@@ -17,7 +17,9 @@ class AbstractEnumGenerator
 
     public function __construct(protected EnumBuilder $builder)
     {
-        /** @var string */
+        /**
+         * @var string $generatedPath
+         */
         $generatedPath = config('paragon.enums.paths.generated');
 
         $this->files = Storage::createLocalDriver([
@@ -37,7 +39,9 @@ class AbstractEnumGenerator
     {
         $imports = $this->imports();
         $suffix = $imports->count() ? PHP_EOL : '';
-        /** @var string */
+        /**
+         * @var string $abstractClass
+         */
         $abstractClass = config('paragon.enums.abstract-class');
 
         return str((string) file_get_contents($this->builder->abstractStubPath()))
@@ -53,12 +57,15 @@ class AbstractEnumGenerator
      */
     protected function imports(): Collection
     {
-        /** @var string */
+        /**
+         * @var string $methodsPath
+         */
         $methodsPath = config('paragon.enums.paths.methods');
 
         try {
             $files = Finder::create()
                 ->files()
+                ->depth(0)
                 ->in(resource_path($methodsPath));
         } catch (DirectoryNotFoundException) {
             return collect();
@@ -72,7 +79,9 @@ class AbstractEnumGenerator
         return $fileCollection
             ->mapWithKeys(function (SplFileInfo $file): array {
                 $filesystem = new FileUtility();
-                /** @var string */
+                /**
+                 * @var string $generatedPath
+                 */
                 $generatedPath = config('paragon.enums.paths.generated');
 
                 $relativeFilePath = $filesystem->makePathRelative(
@@ -80,9 +89,11 @@ class AbstractEnumGenerator
                     resource_path($generatedPath)
                 );
 
-                $name = (string) str($file->getFileName())->before('.');
+                $name = $file->getBasename($this->builder->fileExtension());
 
-                /** @var array<string,string> */
+                /**
+                 * @var array<string,string>
+                 */
                 return [$name => "import {$name} from '{$relativeFilePath}{$file->getFilename()}';" . PHP_EOL];
             })
             ->sort();

--- a/src/Generators/EnumGenerator.php
+++ b/src/Generators/EnumGenerator.php
@@ -7,12 +7,17 @@ use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 use Kirschbaum\Paragon\Concerns\Builders\EnumBuilder;
 use Kirschbaum\Paragon\Concerns\IgnoreParagon;
 use ReflectionEnum;
 use ReflectionEnumBackedCase;
 use ReflectionEnumUnitCase;
 use ReflectionMethod;
+use Symfony\Component\Filesystem\Filesystem as FileUtility;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class EnumGenerator
 {
@@ -20,13 +25,21 @@ class EnumGenerator
 
     protected static Filesystem $files;
 
+    /**
+     * @var Collection<int, SplFileInfo>
+     */
+    protected Collection $imports;
+
     protected ReflectionEnum $reflector;
 
     /**
      * Create new EnumGenerator instance.
      */
-    public function __construct(protected ReflectionEnum $enum, protected EnumBuilder $builder)
-    {
+    public function __construct(
+        protected ReflectionEnum $enum,
+        protected EnumBuilder $builder,
+        protected bool $forceRegenerate = false
+    ) {
         /**
          * @var string $path
          */
@@ -39,17 +52,24 @@ class EnumGenerator
         static::$cache = Storage::createLocalDriver([
             'root' => storage_path('framework/cache/paragon'),
         ]);
+
+        $this->findImports();
     }
 
     public function __invoke(): bool
     {
-        if ($this->generatedFileExists() && $this->cached()) {
+        if (
+            $this->generatedFileExists()
+            && $this->cached()
+            && $this->methodsCached()
+        ) {
             return false;
         }
 
         static::$files->put($this->path(), $this->contents());
 
         $this->cacheEnum();
+        $this->cacheMethods();
 
         return true;
     }
@@ -59,8 +79,9 @@ class EnumGenerator
      */
     protected function contents(): string
     {
+        $imports = $this->imports();
+        $suffix = $imports->count() ? PHP_EOL : '';
         $code = $this->prepareEnumCode();
-
         /**
          * @var string $abstractName
          */
@@ -70,9 +91,42 @@ class EnumGenerator
             ->replace('{{ Path }}', $this->relativePath())
             ->replace('{{ Enum }}', $this->enum->getShortName())
             ->replace('{{ Abstract }}', $abstractName)
+            ->replace('{{ Imports }}', "{$imports->join('')}")
+            ->replace('{{ Methods }}', "{$this->importMethods($imports->keys())}{$suffix}")
             ->replace('{{ TypeDefinition }}', $code->get('type') ?? '')
             ->replace('{{ Cases }}', $code->get('cases') ?? '')
             ->replace('{{ Getters }}', $code->get('getters') ?? '');
+    }
+
+    /**
+     * Build out the actual enum case object including the name, value if needed, and any public methods.
+     *
+     * @return Collection<string, string>
+     */
+    protected function imports(): Collection
+    {
+        return $this->imports
+            ->mapWithKeys(function (SplFileInfo $file): array {
+                $filesystem = new FileUtility();
+
+                /**
+                 * @var string $generatedPath
+                 */
+                $generatedPath = config('paragon.enums.paths.generated');
+
+                $relativeFilePath = $filesystem->makePathRelative(
+                    $file->getPath(),
+                    resource_path($generatedPath)
+                );
+
+                $name = $file->getBasename($this->builder->fileExtension());
+
+                /**
+                 * @var array<string,string>
+                 */
+                return [$name => "import {$name} from '{$relativeFilePath}{$file->getFilename()}';" . PHP_EOL];
+            })
+            ->sort();
     }
 
     /**
@@ -215,6 +269,18 @@ class EnumGenerator
     }
 
     /**
+     * Build out the actual enum case object including the name, value if needed, and any public methods.
+     *
+     * @param  Collection<int, string>  $methods
+     */
+    protected function importMethods(Collection $methods): string
+    {
+        return $methods
+            ->map(fn (string $method): string => PHP_EOL . "{$this->enum->getShortName()}.{$method} = {$method};")
+            ->join('');
+    }
+
+    /**
      * Path where the enum will be saved.
      */
     protected function path(): string
@@ -230,6 +296,24 @@ class EnumGenerator
         return static::$files->exists($this->path());
     }
 
+    protected function findImports(): void
+    {
+        $methodsPath = config('paragon.enums.paths.methods')
+            . DIRECTORY_SEPARATOR
+            . Str::replace('\\', '/', $this->enum->getName());
+
+        try {
+            $this->imports = collect(iterator_to_array(
+                Finder::create()
+                    ->files()
+                    ->depth(0)
+                    ->in(resource_path($methodsPath))
+            ))->values();
+        } catch (DirectoryNotFoundException) {
+            $this->imports = collect();
+        }
+    }
+
     /*
     |--------------------------------------------------------------------------
     | Enum Caching
@@ -238,21 +322,49 @@ class EnumGenerator
 
     protected function cached(): bool
     {
-        return static::$cache->get($this->hashFilename()) === $this->hashFile();
+        return static::$cache->get($this->hashFilename()) === $this->hashFileContents();
     }
 
     protected function hashFilename(): string
     {
-        return md5((string) $this->enum->getFileName());
+        return hash('sha256', (string) $this->enum->getFileName());
     }
 
-    protected function hashFile(): string
+    protected function hashFileContents(): string
     {
-        return (string) md5_file((string) $this->enum->getFileName());
+        return (string) hash_file('sha256', (string) $this->enum->getFileName());
     }
 
     protected function cacheEnum(): void
     {
-        static::$cache->put($this->hashFilename(), $this->hashFile());
+        static::$cache->put($this->hashFilename(), $this->hashFileContents());
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enum Method Caching
+    |--------------------------------------------------------------------------
+    */
+
+    protected function methodsCached(): bool
+    {
+        return static::$cache->get($this->hashMethodsPath()) === $this->hashMethodFileNames();
+    }
+
+    protected function hashMethodsPath(): string
+    {
+        return hash('sha256', $this->path());
+    }
+
+    protected function hashMethodFileNames(): string
+    {
+        $files = $this->imports->map(fn (SplFileInfo $import) => $import->getBasename());
+
+        return $files->isNotEmpty() ? hash('sha256', $files->join('')) : '';
+    }
+
+    protected function cacheMethods(): void
+    {
+        static::$cache->put($this->hashMethodsPath(), $this->hashMethodFileNames());
     }
 }

--- a/src/Generators/EnumGenerator.php
+++ b/src/Generators/EnumGenerator.php
@@ -114,17 +114,17 @@ class EnumGenerator
                  */
                 $generatedPath = config('paragon.enums.paths.generated');
 
-                $relativeFilePath = $filesystem->makePathRelative(
-                    $file->getPath(),
-                    resource_path($generatedPath)
-                );
+                $relativeFilePath = Str::of($filesystem->makePathRelative(
+                    $file->getPathname(),
+                    resource_path($generatedPath) . DIRECTORY_SEPARATOR . $this->filePath()
+                ))->rtrim('/');
 
                 $name = $file->getBasename($this->builder->fileExtension());
 
                 /**
                  * @var array<string,string>
                  */
-                return [$name => "import {$name} from '{$relativeFilePath}{$file->getFilename()}';" . PHP_EOL];
+                return [$name => "import {$name} from '{$relativeFilePath}';" . PHP_EOL];
             })
             ->sort();
     }
@@ -281,7 +281,7 @@ class EnumGenerator
     }
 
     /**
-     * Path where the enum will be saved.
+     * File path where the enum will be saved.
      */
     protected function path(): string
     {
@@ -289,6 +289,18 @@ class EnumGenerator
             ->after('App\\Enums\\')
             ->replace('\\', '/')
             ->finish($this->builder->fileExtension());
+    }
+
+    /**
+     * Directory path where the enum will be saved.
+     */
+    protected function filePath(): string
+    {
+        if (Str::contains($this->path(), '/')) {
+            return Str::beforeLast($this->path(), '/');
+        }
+
+        return '';
     }
 
     protected function generatedFileExists(): bool

--- a/stubs/enum-js.stub
+++ b/stubs/enum-js.stub
@@ -1,5 +1,5 @@
 import {{ Abstract }} from '{{ Path }}{{ Abstract }}.js';
-
+{{ Imports }}
 class {{ Enum }} extends {{ Abstract }} {
     static items = Object.freeze({
 {{ Cases }},
@@ -7,5 +7,5 @@ class {{ Enum }} extends {{ Abstract }} {
 
 {{ Getters }}
 }
-
+{{ Methods }}
 export default {{ Enum }};

--- a/stubs/enum.stub
+++ b/stubs/enum.stub
@@ -1,5 +1,5 @@
 import {{ Abstract }} from '{{ Path }}{{ Abstract }}.ts';
-
+{{ Imports }}
 type {{ Enum }}Definition = {
     name: string;{{ TypeDefinition }}
 };
@@ -11,5 +11,5 @@ class {{ Enum }} extends {{ Abstract }} {
 
 {{ Getters }}
 }
-
+{{ Methods }}
 export default {{ Enum }};

--- a/stubs/enum.stub
+++ b/stubs/enum.stub
@@ -12,4 +12,6 @@ class {{ Enum }} extends {{ Abstract }} {
 {{ Getters }}
 }
 {{ Methods }}
+export type { {{ Enum }}Definition };
+
 export default {{ Enum }};

--- a/tests/Unit/Commands/MakeEnumMethodCommandTest.php
+++ b/tests/Unit/Commands/MakeEnumMethodCommandTest.php
@@ -1,28 +1,68 @@
 <?php
 
+use App\Enums\StringBacked;
 use Kirschbaum\Paragon\Commands\MakeEnumMethodCommand;
 
-it('generates enum methods', function () {
+it('generates global enum methods', function () {
     // Act.
-    $this->artisan(MakeEnumMethodCommand::class, ['name' => 'asOptions']);
+    $method = 'asOptions';
 
-    $path = resource_path(config('paragon.enums.paths.methods') . DIRECTORY_SEPARATOR . 'asOptions.ts');
+    $this->artisan(MakeEnumMethodCommand::class, ['name' => $method, '--global' => true]);
+
+    $path = resource_path(config('paragon.enums.paths.methods') . DIRECTORY_SEPARATOR . "{$method}.ts");
     $file = file_get_contents($path);
 
     // Assert.
     expect($path)->toBeFile()
         ->and($file)
-        ->toContain('export default function asOptions()');
+        ->toContain("export default function {$method}()");
 });
 
-it('imports the method into the base enum', function () {
+it('imports the global method into the base enum', function () {
     // Act.
-    $this->artisan(MakeEnumMethodCommand::class, ['name' => 'asOptions']);
+    $method = 'asOptions';
+
+    $this->artisan(MakeEnumMethodCommand::class, ['name' => $method, '--global' => true]);
 
     $file = file_get_contents(resource_path(config('paragon.enums.paths.generated') . DIRECTORY_SEPARATOR . 'Enum.ts'));
 
     // Assert.
     expect($file)
-        ->toContain('import asOptions from')
-        ->toContain('Enum.asOptions = asOptions;');
+        ->toContain("import {$method} from")
+        ->toContain("Enum.{$method} = {$method};");
+});
+
+it('generates enum methods', function () {
+    // Act.
+    $method = 'asOptions';
+
+    $this->artisan(MakeEnumMethodCommand::class, ['name' => $method, '--enum' => StringBacked::class]);
+
+    $path = (string) Str::of(resource_path(config('paragon.enums.paths.methods')))
+        ->append(DIRECTORY_SEPARATOR)
+        ->append(Str::replace('\\', '/', StringBacked::class))
+        ->append(DIRECTORY_SEPARATOR)
+        ->append("{$method}.ts");
+
+    $file = file_get_contents($path);
+
+    // Assert.
+    expect($path)->toBeFile()
+        ->and($file)
+        ->toContain("export default function {$method}()");
+});
+
+it('imports the method into the enum', function () {
+    // Act.
+    $method = 'asOptions';
+    $enum = class_basename(StringBacked::class);
+
+    $this->artisan(MakeEnumMethodCommand::class, ['name' => $method, '--enum' => StringBacked::class]);
+
+    $file = file_get_contents(resource_path(config('paragon.enums.paths.generated') . DIRECTORY_SEPARATOR . "{$enum}.ts"));
+
+    // Assert.
+    expect($file)
+        ->toContain("import {$method} from")
+        ->toContain("{$enum}.{$method} = {$method};");
 });

--- a/tests/Unit/Commands/MakeJsEnumMethodCommandTest.php
+++ b/tests/Unit/Commands/MakeJsEnumMethodCommandTest.php
@@ -1,28 +1,68 @@
 <?php
 
+use App\Enums\StringBacked;
 use Kirschbaum\Paragon\Commands\MakeEnumMethodCommand;
 
-it('generates enum methods', function () {
+it('generates global enum methods', function () {
     // Act.
-    $this->artisan(MakeEnumMethodCommand::class, ['name' => 'asOptions', '--javascript' => true]);
+    $method = 'asOptions';
 
-    $path = resource_path(config('paragon.enums.paths.methods') . DIRECTORY_SEPARATOR . 'asOptions.js');
+    $this->artisan(MakeEnumMethodCommand::class, ['name' => $method, '--javascript' => true, '--global' => true]);
+
+    $path = resource_path(config('paragon.enums.paths.methods') . DIRECTORY_SEPARATOR . "{$method}.js");
     $file = file_get_contents($path);
 
     // Assert.
     expect($path)->toBeFile()
         ->and($file)
-        ->toContain('export default function asOptions()');
+        ->toContain("export default function {$method}()");
 });
 
-it('imports the method into the base enum', function () {
+it('imports the global method into the base enum', function () {
     // Act.
-    $this->artisan(MakeEnumMethodCommand::class, ['name' => 'asOptions', '--javascript' => true]);
+    $method = 'asOptions';
+
+    $this->artisan(MakeEnumMethodCommand::class, ['name' => $method, '--javascript' => true, '--global' => true]);
 
     $file = file_get_contents(resource_path(config('paragon.enums.paths.generated') . DIRECTORY_SEPARATOR . 'Enum.js'));
 
     // Assert.
     expect($file)
-        ->toContain('import asOptions from')
-        ->toContain('Enum.asOptions = asOptions;');
+        ->toContain("import {$method} from")
+        ->toContain("Enum.{$method} = {$method};");
+});
+
+it('generates enum methods', function () {
+    // Act.
+    $method = 'asOptions';
+
+    $this->artisan(MakeEnumMethodCommand::class, ['name' => $method, '--javascript' => true, '--enum' => StringBacked::class]);
+
+    $path = (string) Str::of(resource_path(config('paragon.enums.paths.methods')))
+        ->append(DIRECTORY_SEPARATOR)
+        ->append(Str::replace('\\', '/', StringBacked::class))
+        ->append(DIRECTORY_SEPARATOR)
+        ->append("{$method}.js");
+
+    $file = file_get_contents($path);
+
+    // Assert.
+    expect($path)->toBeFile()
+        ->and($file)
+        ->toContain("export default function {$method}()");
+});
+
+it('imports the method into the enum', function () {
+    // Act.
+    $method = 'asOptions';
+    $enum = class_basename(StringBacked::class);
+
+    $this->artisan(MakeEnumMethodCommand::class, ['name' => $method, '--javascript' => true, '--enum' => StringBacked::class]);
+
+    $file = file_get_contents(resource_path(config('paragon.enums.paths.generated') . DIRECTORY_SEPARATOR . "{$enum}.js"));
+
+    // Assert.
+    expect($file)
+        ->toContain("import {$method} from")
+        ->toContain("{$enum}.{$method} = {$method};");
 });


### PR DESCRIPTION
This adds the ability to create methods for individual enums. It moves existing behavior behind the `--global` flag for enum methods intended for globally available behavior. This is fully tested and ready to go.